### PR TITLE
`preventDefault()` only in case of double focus on input `radio`and `checkbox`

### DIFF
--- a/lib/tablist.js
+++ b/lib/tablist.js
@@ -159,9 +159,9 @@
      * @param {DOMEvent} e - A `FocusEvent` or `KeyboardEvent` object
      */
     this.handlePanelFocus = function handlePanelFocus( e ){
-      e.preventDefault();
 
       if( e.target.doubleFocus ){
+        e.preventDefault();
         delete e.target.doubleFocus;
         return;
       }


### PR DESCRIPTION
`preventDefault()` was called a bit too early in the process of getting the current tab index.

Resolve #4 