### PR TITLE
`data-open` do not need `"true"` as value

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Basic HTML structure with roles `tablist`, `tab`, and `tabpanel`.
 
 An `aria-disabled` attribute set to `true` on a `tab` will disable the `tab` and the associated `tabpanel` making them unfocusable and unselectable.
 
-If you wish to open one specific tab when the script starts, just add the `data-open` attribute with the value of `true` on the desired `tab`:
+If you wish to open one specific tab when the script starts, just add the `data-open` attribute on the desired `tab` (without any value or with every other value than `"false"`, it will be considered as `true`):
 
 ```html
 <ul role="tablist">

--- a/lib/index.js
+++ b/lib/index.js
@@ -331,7 +331,7 @@ class Tablist{
       tab.disabled = tab.hasAttribute( 'disabled' ) || tab.getAttribute( 'aria-disabled' ) === 'true';
 
       // if there's no opened tab yet
-      if( tab.getAttribute( 'data-open' ) === 'true' && !tab.disabled ){
+      if( tab.hasAttribute( 'data-open' ) && tab.getAttribute( 'data-open' ) !== 'false' && !tab.disabled ){
         if( this._tablist.openedIndex === undefined ){
           this._toggleDisplay( index, true );
 


### PR DESCRIPTION
Consider `data-open` without value as `true`.
Only consider `data-open="false"` as `false`.